### PR TITLE
Fix syntax issues and complete DE/EN language coverage

### DIFF
--- a/docs/INTERFACE/API/INTERFACE_API.md
+++ b/docs/INTERFACE/API/INTERFACE_API.md
@@ -1,25 +1,25 @@
 # LAP-TEQ PLUS INTERFACE HTTP-API
 
-## Introduction
-This document describes the HTTP-API of the LAP-TEQ PLUS INTERFACE. With this API it is possible to integrate LAP-TEQ Sensors into existing control systems. To avoid confusion, the LAP-TEQ PLUS INTERFACE is referred to as LTPI in the following.
-Although there is no risk involved using the API, implementing it into an existing control system is at your own risk. The API and this documentation can be subject to change, whenever the device firmware will be updated. TEQSAS GmbH does not assume liability whatsoever for any damages caused by 3rd party implementations of the API.
+## Einleitung
+Dieses Dokument beschreibt die HTTP-API des LAP-TEQ PLUS INTERFACE. Mit dieser API ist es möglich, LAP-TEQ Sensoren in bestehende Steuerungssysteme zu integrieren. Zur Vermeidung von Verwechslungen wird das LAP-TEQ PLUS INTERFACE im Folgenden als LTPI bezeichnet.
+Obwohl die Nutzung der API kein Risiko birgt, erfolgt die Einbindung in ein bestehendes Steuerungssystem auf eigene Gefahr. Die API und diese Dokumentation können sich ändern, sobald die Geräte-Firmware aktualisiert wird. Die TEQSAS GmbH übernimmt keinerlei Haftung für Schäden, die durch Drittimplementierungen der API entstehen.
 
-This documentation must not be redistributed.
+Diese Dokumentation darf nicht weiterverbreitet werden.
 
-This document describes the API as of today (2024/06/13).
+Dieses Dokument beschreibt die API mit Stand vom 13.06.2024.
 
-If you find any bugs or errors using the system, please send a report to support@teqsas.de including a detailed description of the issue. 
+Wenn Sie Bugs oder Fehler im System finden, senden Sie bitte einen Bericht mit einer detaillierten Beschreibung des Problems an support@teqsas.de. 
 
 ## API-Commands
 
 ### Connecting to a LTPI
 The LTPI is a TCP/IP device and listens to HTTP requests. An example request for checking the connection and the state of the LTPI would look like the following:
 
-```GET http://{ip-adress}/lt```
+```GET http://{ip-address}/lt```
 
 This returns a response in JSON-format which could look like this:
 
-```
+```json
 {
   "0": {
     "lbl": "Amps SR",
@@ -75,7 +75,7 @@ Further information on interpreting the JSON data can be found in chapter Readin
 
 HTTP-Request:
 
-```GET http://{ip-adress}/lt?c=1{sensor-number}```
+```GET http://{ip-address}/lt?c=1{sensor-number}```
 
 Provide the sensor number which corresponds to the XLR-port on the LTPI Hardware to turn on this sensor. Normal mode means, the sensor will start just like a single click on the webapp or reading out with a LAP-TEQ PLUS DISPLAY. E.g. if two sensors are connected in daisychain, both sensors will be started.
 Returns a JSON document like in Chapter Connecting to a LTPI.
@@ -84,7 +84,7 @@ Returns a JSON document like in Chapter Connecting to a LTPI.
 
 HTTP-Request:
 
-```GET http://{ip-adress}/lt?c=17```
+```GET http://{ip-address}/lt?c=17```
 
 This starts all connected sensors. Normal mode means, the sensor will start just like a single click on the webapp or reading out with a LAP-TEQ PLUS DISPLAY. E.g. if two sensors are connected in daisychain, both sensors will be started.
 Returns a JSON document like in -1.1 Connecting to a LTPI-
@@ -93,7 +93,7 @@ Returns a JSON document like in -1.1 Connecting to a LTPI-
 
 HTTP-Request:
 
-```GET http://{ip-adress}/lt?c=2{sensor-number}```
+```GET http://{ip-address}/lt?c=2{sensor-number}```
 
 Provide the sensor number which corresponds to the XLR-port on the LTPI Hardware on which the LAP-TEQ PLUS ATMOSPHERE sensor is connected. If on this sensor-line an ATMOSPHERE sensor and e.g. an INCLINOMETER is connected, only the ATMOSPHERE sensor will be turned on. This also works with 1.2.2 Start all connected sensors in normal mode.
 Returns a JSON document like in -1.1 Connecting to a LTPI-
@@ -136,7 +136,7 @@ Key | Description
 
 HTTP-Request:
 
-```GET http://{ip-adress}/lt?c=0{sensor-number}```
+```GET http://{ip-address}/lt?c=0{sensor-number}```
 
 Provide the sensor number which corresponds to the XLR-port on the LTPI Hardware to turn this sensor off. 
 Returns a JSON document like in -1.1 Connecting to a LTPI-
@@ -145,7 +145,7 @@ Returns a JSON document like in -1.1 Connecting to a LTPI-
 
 HTTP-Request:
 
-```GET http://{ip-adress}/lt?c=07```
+```GET http://{ip-address}/lt?c=07```
 
 Turns off all connected sensors.
 Returns a JSON document like in -1.1 Connecting to a LTPI-
@@ -153,18 +153,18 @@ Returns a JSON document like in -1.1 Connecting to a LTPI-
 ##	Other Functions
 ###	Network Scan
 HTTP-Request:
-```GET http://{ip-adress}/scan```
+```GET http://{ip-address}/scan```
 
 Start scanning the network for other connected LTPIs. 
 
 ###	Reading the list of connected LTPIs
 HTTP-Request:
 
-```GET http://{ip-adress}/nbors.json```
+```GET http://{ip-address}/nbors.json```
 
 Returns a JSON object containing the LTPI information of this LTPI and other LTPIs connected to the network. To update the list please perform 1.5.1 Network Scan.
 
-```
+```json
 {
   "0": {
     "dn": "Amps SR",

--- a/docs/en/INTERFACE/API/INTERFACE_API.md
+++ b/docs/en/INTERFACE/API/INTERFACE_API.md
@@ -15,11 +15,11 @@ If you find any bugs or errors using the system, please send a report to support
 ### Connecting to a LTPI
 The LTPI is a TCP/IP device and listens to HTTP requests. An example request for checking the connection and the state of the LTPI would look like the following:
 
-```GET http://{ip-adress}/lt```
+```GET http://{ip-address}/lt```
 
 This returns a response in JSON-format which could look like this:
 
-```
+```json
 {
   "0": {
     "lbl": "Amps SR",
@@ -75,7 +75,7 @@ Further information on interpreting the JSON data can be found in chapter Readin
 
 HTTP-Request:
 
-```GET http://{ip-adress}/lt?c=1{sensor-number}```
+```GET http://{ip-address}/lt?c=1{sensor-number}```
 
 Provide the sensor number which corresponds to the XLR-port on the LTPI Hardware to turn on this sensor. Normal mode means, the sensor will start just like a single click on the webapp or reading out with a LAP-TEQ PLUS DISPLAY. E.g. if two sensors are connected in daisychain, both sensors will be started.
 Returns a JSON document like in Chapter Connecting to a LTPI.
@@ -84,7 +84,7 @@ Returns a JSON document like in Chapter Connecting to a LTPI.
 
 HTTP-Request:
 
-```GET http://{ip-adress}/lt?c=17```
+```GET http://{ip-address}/lt?c=17```
 
 This starts all connected sensors. Normal mode means, the sensor will start just like a single click on the webapp or reading out with a LAP-TEQ PLUS DISPLAY. E.g. if two sensors are connected in daisychain, both sensors will be started.
 Returns a JSON document like in -1.1 Connecting to a LTPI-
@@ -93,7 +93,7 @@ Returns a JSON document like in -1.1 Connecting to a LTPI-
 
 HTTP-Request:
 
-```GET http://{ip-adress}/lt?c=2{sensor-number}```
+```GET http://{ip-address}/lt?c=2{sensor-number}```
 
 Provide the sensor number which corresponds to the XLR-port on the LTPI Hardware on which the LAP-TEQ PLUS ATMOSPHERE sensor is connected. If on this sensor-line an ATMOSPHERE sensor and e.g. an INCLINOMETER is connected, only the ATMOSPHERE sensor will be turned on. This also works with 1.2.2 Start all connected sensors in normal mode.
 Returns a JSON document like in -1.1 Connecting to a LTPI-
@@ -136,7 +136,7 @@ Key | Description
 
 HTTP-Request:
 
-```GET http://{ip-adress}/lt?c=0{sensor-number}```
+```GET http://{ip-address}/lt?c=0{sensor-number}```
 
 Provide the sensor number which corresponds to the XLR-port on the LTPI Hardware to turn this sensor off. 
 Returns a JSON document like in -1.1 Connecting to a LTPI-
@@ -145,7 +145,7 @@ Returns a JSON document like in -1.1 Connecting to a LTPI-
 
 HTTP-Request:
 
-```GET http://{ip-adress}/lt?c=07```
+```GET http://{ip-address}/lt?c=07```
 
 Turns off all connected sensors.
 Returns a JSON document like in -1.1 Connecting to a LTPI-
@@ -153,18 +153,18 @@ Returns a JSON document like in -1.1 Connecting to a LTPI-
 ##	Other Functions
 ###	Network Scan
 HTTP-Request:
-```GET http://{ip-adress}/scan```
+```GET http://{ip-address}/scan```
 
 Start scanning the network for other connected LTPIs. 
 
 ###	Reading the list of connected LTPIs
 HTTP-Request:
 
-```GET http://{ip-adress}/nbors.json```
+```GET http://{ip-address}/nbors.json```
 
 Returns a JSON object containing the LTPI information of this LTPI and other LTPIs connected to the network. To update the list please perform 1.5.1 Network Scan.
 
-```
+```json
 {
   "0": {
     "dn": "Amps SR",

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,0 +1,3 @@
+# TEQSAS PRODUCTS
+
+Here you can find the latest documentation and information about TEQSAS PRODUCTS

--- a/docs/en/support/support.md
+++ b/docs/en/support/support.md
@@ -1,0 +1,8 @@
+# Support
+
+If you have any further questions or you might think your device does not work as intended, please contact our support. 
+
+We are always listening on the following Email-Adress:
+
+[support@teqsas.de](mailto:support@teqsas.de)
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
-#TEQSAS PRODUCTS
+# TEQSAS PRODUCTS
 
-Here you can find the latest documentation and information about TEQSAS PRODUCTS
+Hier finden Sie die aktuelle Dokumentation und Informationen zu TEQSAS PRODUCTS

--- a/docs/support/support.md
+++ b/docs/support/support.md
@@ -1,8 +1,8 @@
 # Support
 
-If you have any further questions or you might think your device does not work as intended, please contact our support. 
+Wenn Sie weitere Fragen haben oder denken, dass Ihr Gerät nicht wie vorgesehen funktioniert, kontaktieren Sie bitte unseren Support.
 
-We are always listening on the following Email-Adress:
+Sie erreichen uns jederzeit unter der folgenden E-Mail-Adresse:
 
 [support@teqsas.de](mailto:support@teqsas.de)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: TEQSAS PRODUCTS Documentation
+site_name: TEQSAS PRODUCTS
 site_url: https://docs.teqsas.de/
 
 extra_css:
@@ -37,8 +37,8 @@ theme:
 
 
 nav:
-  - Home: index.md
-  - Products:
+  - Startseite: index.md
+  - Produkte:
     - 'PAN-C':
       - PANC/index.md
       - Bedienungsanleitung:
@@ -95,6 +95,8 @@ plugins:
           name: English
           build: true
           nav_translations:
+            Startseite: Home
+            Produkte: Products
             Bedienungsanleitung: Manual
             Bevor Sie beginnen: Before you begin
             Zu Ihrer Sicherheit: For your safety

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -2,7 +2,7 @@
     <div class="md-footer-meta__inner md-grid">
       <div class="md-footer-copyright">
           <div class="md-footer-copyright__highlight">
-            &copy; 2024 <a href="https://teqsas.de"  target="_blank" rel="noopener">TEQSAS GmbH</a>
+            &copy; 2024 <a href="https://teqsas.de" target="_blank" rel="noopener">TEQSAS GmbH</a>
           </div>
         </div>
     </div>


### PR DESCRIPTION
Phase 1 of docs review: syntax-only fixes plus 1:1 language mirroring.
No content was added or rephrased; existing English content has been
translated into German where the German default page was missing it,
and the previously missing English mirror pages were added verbatim.

Syntax / config fixes:
- docs/index.md: add missing space in H1 (#TEQSAS -> # TEQSAS)
- docs/INTERFACE/API/INTERFACE_API.md (+ EN mirror): fix typo
  {ip-adress} -> {ip-address} (8 occurrences each)
- docs/INTERFACE/API/INTERFACE_API.md (+ EN mirror): add language
  tags (json) to fenced code blocks for syntax highlighting
- overrides/partials/footer.html: collapse double space in <a> tag
- mkdocs.yml: site_name TEQSAS PRODUCTS Documentation -> TEQSAS PRODUCTS
- mkdocs.yml: top-level nav now DE (Startseite, Produkte) with
  nav_translations entries for the EN build

Language coverage (1:1 translations, no new content):
- docs/index.md: translated existing English sentence into German
- docs/en/index.md: new file with the previous English wording
- docs/support/support.md: translated existing English text into German
- docs/en/support/support.md: new file with the previous English text
- docs/INTERFACE/API/INTERFACE_API.md: Introduction section translated
  into German; the rest of the reference remains English as decided

