### PR TITLE
LAP-TEQ PLUS: Bestellnummern entfernen und Ladegerät aus Lieferumfang streichen

### DIFF
--- a/docs/LAPTEQPLUS/Manual/manual_11.md
+++ b/docs/LAPTEQPLUS/Manual/manual_11.md
@@ -31,17 +31,6 @@
 | Abmessungen                 | 121,5 × 38,5 × 32,7 mm                             |
 | Gewicht                     | 170 g                                              |
 
-## Netzstecker-Ladegerät
-
-| Netzstecker-Ladegerät |                       |
-|-----------------------|------------------------|
-| Nennspannung          | 100–240 V~, 50–60 Hz   |
-| Ladespannung          | 5 V                    |
-| Ladestrom             | max. 1 A               |
-| Ladeanschluss         | Micro USB              |
-| Abmessungen           | 70 × 36 × 14 mm        |
-| Schutzklasse          | II                     |
-
 ## Akku
 
 | Akku          |                |
@@ -59,14 +48,3 @@
 | USB-Ladekabel    | Micro USB (APCBU10BBECSTD)                 |
 
 Der Hersteller behält sich das Recht vor, technische Änderungen ohne vorherige Ankündigungen an dem Produkt / an der Produktgruppe vorzunehmen.
-
-## Bestellnummern für Einzelkomponenten
-
-| Komponente                          | Bestellnummer |
-|-------------------------------------|---------------|
-| LAP-TEQ PLUS INCLINOMETER Unit      | T87001004     |
-| LAP-TEQ PLUS Display Unit           | T87001005     |
-| LAP-TEQ PLUS Koffer mit Inlay       | T87001006     |
-| LAP-TEQ PLUS Kalibrierkabel         | T87001013     |
-| LAP-TEQ PLUS Angle Notes            | T87001014     |
-| LAP-TEQ PLUS Note Pen               | T87001015     |

--- a/docs/LAPTEQPLUS/Manual/manual_3.md
+++ b/docs/LAPTEQPLUS/Manual/manual_3.md
@@ -6,7 +6,6 @@
 
 - 1× LAP-TEQ Display PLUS (kurz Displaymodul)
 - 2× LAP-TEQ PLUS INCLINOMETER
-- 1× Netzstecker-USB-Ladegerät
 - 1× USB-Ladekabel
 - 1× Kalibrier-Kabel
 - 1× Sicherheitshinweise

--- a/docs/LAPTEQPLUS/Manual/manual_4.md
+++ b/docs/LAPTEQPLUS/Manual/manual_4.md
@@ -3,7 +3,7 @@
 ## 4.1 Akku laden
 Vor der ersten Inbetriebnahme muss der Akku aufgeladen werden.
 
-Ist kein Ladegerät angeschlossen, wird der Ladezustand des Akkus bei eingeschaltetem Gerät im Display angezeigt.
+Ist das Gerät nicht mit einer Stromquelle verbunden, wird der Ladezustand des Akkus bei eingeschaltetem Gerät im Display angezeigt.
 
 !!! abstract "Achtung!"
     **Gefahr von Geräteschäden!**
@@ -12,9 +12,6 @@ Ist kein Ladegerät angeschlossen, wird der Ladezustand des Akkus bei eingeschal
 
 !!! info "Hinweis"
     Der Li-Polymer-Akku kann jederzeit aufgeladen werden, ohne die Lebensdauer zu verkürzen. Eine Unterbrechung des Ladevorgangs beschädigt den Akku nicht.
-
-!!! info "Hinweis"
-    Ist der Akku vollständig geladen, stellt sich das Netzstecker-USB-Ladegerät automatisch auf Erhaltungsladung um. Der Akku kann dauerhaft in der Ladestation verbleiben.
 
 !!! info "Hinweis"
     Wenn das Gerät längere Zeit nicht verwendet wird, entlädt es sich. In diesem Fall muss es vor der Verwendung aufgeladen werden.
@@ -29,7 +26,7 @@ Ist kein Ladegerät angeschlossen, wird der Ladezustand des Akkus bei eingeschal
 <!-- TODO: Abbildung "Anschluss des Ladekabels am Displaymodul" einfügen -->
 
 * USB-Ladekabel (1) in die USB-Buchse (2) am Displaymodul stecken.
-* Netzstecker-USB-Ladegerät (3) in eine Schuko- oder Eurosteckdose stecken.
+* Das andere Ende des USB-Ladekabels mit einer geeigneten USB-Stromquelle (z. B. USB-Anschluss eines Computers oder Netzteil) verbinden.
 
 Bei eingeschaltetem Gerät wird der Ladevorgang durch einen blauen Pfeil im Display dargestellt.
 
@@ -39,7 +36,7 @@ Der Ladezustand wird durch die Kontrollleuchte (4) angezeigt:
 - Grüne LED – voll aufgeladen
 
 * Beenden Sie den Ladevorgang, wenn der Akku geladen ist.
-* Trennen Sie das Netzstecker-USB-Ladegerät vom Stromanschluss, solange Sie es nicht verwenden.
+* Trennen Sie das USB-Ladekabel von der Stromquelle, solange Sie es nicht verwenden.
 
 ## 4.2 Anschluss
 

--- a/docs/en/LAPTEQPLUS/Manual/manual_11.md
+++ b/docs/en/LAPTEQPLUS/Manual/manual_11.md
@@ -31,17 +31,6 @@
 | Dimensions                 | 121.5 × 38.5 × 32.7 mm                             |
 | Weight                     | 170 g                                              |
 
-## Mains plug charger
-
-| Mains plug charger    |                       |
-|-----------------------|------------------------|
-| Nominal voltage       | 100–240 V~, 50–60 Hz   |
-| Charging voltage      | 5 V                    |
-| Charging current      | max. 1 A               |
-| Charging connection   | Micro USB              |
-| Dimensions            | 70 × 36 × 14 mm        |
-| Protection class      | II                     |
-
 ## Battery
 
 | Battery       |                |
@@ -59,14 +48,3 @@
 | USB charging cable| Micro USB (APCBU10BBECSTD)                 |
 
 The manufacturer reserves the right to make technical changes to the product / product group without prior notice.
-
-## Order numbers for individual components
-
-| Component                           | Order number  |
-|-------------------------------------|---------------|
-| LAP-TEQ PLUS INCLINOMETER Unit      | T87001004     |
-| LAP-TEQ PLUS Display Unit           | T87001005     |
-| LAP-TEQ PLUS case with inlay        | T87001006     |
-| LAP-TEQ PLUS calibration cable      | T87001013     |
-| LAP-TEQ PLUS Angle Notes            | T87001014     |
-| LAP-TEQ PLUS Note Pen               | T87001015     |

--- a/docs/en/LAPTEQPLUS/Manual/manual_3.md
+++ b/docs/en/LAPTEQPLUS/Manual/manual_3.md
@@ -6,7 +6,6 @@
 
 - 1× LAP-TEQ Display PLUS (display module for short)
 - 2× LAP-TEQ PLUS INCLINOMETER
-- 1× Mains plug USB charger
 - 1× USB charging cable
 - 1× Calibration cable
 - 1× Safety instructions

--- a/docs/en/LAPTEQPLUS/Manual/manual_4.md
+++ b/docs/en/LAPTEQPLUS/Manual/manual_4.md
@@ -3,7 +3,7 @@
 ## 4.1 Charging the battery
 The battery must be charged before initial use.
 
-If no charger is connected, the battery charge level is shown on the display when the device is switched on.
+If the device is not connected to a power source, the battery charge level is shown on the display when the device is switched on.
 
 !!! abstract "Attention!"
     **Risk of damage to the appliance!**
@@ -12,9 +12,6 @@ If no charger is connected, the battery charge level is shown on the display whe
 
 !!! info "Note"
     The Li-Polymer battery can be charged at any time without shortening its service life. Interrupting the charging process does not damage the battery.
-
-!!! info "Note"
-    When the battery is fully charged, the mains plug USB charger automatically switches to trickle charging. The battery may remain in the charging station permanently.
 
 !!! info "Note"
     If the device is not used for a long time, it discharges. In that case it must be charged before use.
@@ -29,7 +26,7 @@ If no charger is connected, the battery charge level is shown on the display whe
 <!-- TODO: Insert image "Connecting the charging cable to the display module" -->
 
 * Plug the USB charging cable (1) into the USB socket (2) on the display module.
-* Plug the mains plug USB charger (3) into a Schuko or Euro mains socket.
+* Connect the other end of the USB charging cable to a suitable USB power source (e.g. USB port of a computer or a USB power adapter).
 
 When the device is switched on, the charging process is indicated by a blue arrow on the display.
 
@@ -39,7 +36,7 @@ The charge level is shown by the indicator light (4):
 - Green LED – fully charged
 
 * End the charging process once the battery is charged.
-* Disconnect the mains plug USB charger from the mains as long as you are not using it.
+* Disconnect the USB charging cable from the power source as long as you are not using it.
 
 ## 4.2 Connection
 


### PR DESCRIPTION
Der Abschnitt mit den Bestellnummern für Einzelkomponenten wurde aus den
technischen Daten entfernt. Da kein Netzstecker-USB-Ladegerät mehr mit dem
Produkt geliefert wird, sondern nur noch das USB-Ladekabel, wurden alle
Verweise auf das Ladegerät aus Lieferumfang, Inbetriebnahme und technischen
Daten in beiden Sprachversionen (DE/EN) entfernt bzw. angepasst.